### PR TITLE
Update path to browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A boiler plate for Vue projects",
   "scripts": {
     "dev": "watchify -v -t vueify -e src/main.js -o public/js/build.js",
-    "build": "NODE_ENV=production ./node_modules/watchify/node_modules/.bin/browserify -t vueify -e src/main.js | uglifyjs -c warnings=false -m > public/js/build.min.js",
+    "build": "NODE_ENV=production ./node_modules/.bin/browserify -t vueify -e src/main.js | uglifyjs -c warnings=false -m > public/js/build.min.js",
     "sync": "browser-sync start --server public --files public/js/build.js --reload-debounce 500"
   },
   "author": "Bill Criswell",


### PR DESCRIPTION
Fresh install put `browserify` in the `node_modules/.bin` folder rather than `node_modules/watchify/node_modules/.bin/broswerify`.  `npm run build` didn't work because of this.  Practicing with Git so I thought I'd make a pull request.